### PR TITLE
Added support for crystal-db 0.11.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ dependencies:
   pg:
     github: will/crystal-pg
 
-crystal: ">= 0.36, < 2.0.0"
+crystal: ">= 0.36"
 
 license: MIT

--- a/src/postgis.cr
+++ b/src/postgis.cr
@@ -5,6 +5,8 @@ require "./version"
 
 module PostGIS
   abstract struct Geography
+    include DB::Mappable
+
     def self.from_ewkb(io : IO, endian : IO::ByteFormat)
       # TODO: Come up with a better way to distinguish this. Maybe generics?
       # I'm not sure of the best way to do it yet, I was just trying to come up
@@ -20,9 +22,12 @@ module PostGIS
   end
 
   struct Point2D < Geography
-    getter x : Float64
-    getter y : Float64
-    getter srid : UInt32
+    @srid : UInt32 = 4326_u32
+    @x : Float64 = 0.0f64
+    @y : Float64 = 0.0f64
+    getter x
+    getter y
+    getter srid
 
     def self.from_ewkb(io, endian : IO::ByteFormat) : self
       new(
@@ -34,9 +39,27 @@ module PostGIS
 
     def initialize(@x, @y, @srid = 4326_u32)
     end
+
+    def initialize(query_methods : DB::ResultSet)
+      bytes = query_methods.read(Slice(UInt8))
+      io = IO::Memory.new(bytes)
+      endian_byte = io.read_bytes(UInt8)
+      endian = endian_byte == 0x01 ? IO::ByteFormat::LittleEndian : IO::ByteFormat::BigEndian
+      type = io.read_bytes UInt32, endian
+      unless type == 0x20000001
+        raise DecodingError.new("This geography is not Point2D: #{type.to_s(16)}")
+      end
+      @srid = io.read_bytes(UInt32, endian)
+      @x = io.read_bytes(Float64, endian)
+      @y = io.read_bytes(Float64, endian)
+    end
   end
 
   struct Point3D < Geography
+    @srid : UInt32 = 4326_u32
+    @x : Float64 = 0.0f64
+    @y : Float64 = 0.0f64
+    @z : Float64 = 0.0f64
     getter x : Float64
     getter y : Float64
     getter z : Float64
@@ -53,9 +76,25 @@ module PostGIS
 
     def initialize(@srid, @x, @y, @z)
     end
+
+    def initialize(query_methods : DB::ResultSet)
+      bytes = query_methods.read(Slice(UInt8))
+      io = IO::Memory.new(bytes)
+      endian_byte = io.read_bytes(UInt8)
+      endian = endian_byte == 0x01 ? IO::ByteFormat::LittleEndian : IO::ByteFormat::BigEndian
+      type = io.read_bytes UInt32, endian
+      unless type == 0xA0000001
+        raise DecodingError.new("This geography is not Point3D: #{type.to_s(16)}")
+      end
+      @srid = io.read_bytes(UInt32, endian)
+      @x = io.read_bytes(Float64, endian)
+      @y = io.read_bytes(Float64, endian)
+      @z = io.read_bytes(Float64, endian)
+    end
   end
 
   struct Polygon2D < Geography
+    @sections : Array(Array(Point2D)) = Array(Array(Point2D)).new
     getter sections : Array(Array(Point2D))
 
     def self.from_ewkb(io, endian) : self
@@ -75,6 +114,27 @@ module PostGIS
     end
 
     def initialize(@sections)
+    end
+
+    def initialize(query_methods : DB::ResultSet)
+      bytes = query_methods.read(Slice(UInt8))
+      io = IO::Memory.new(bytes)
+      endian_byte = io.read_bytes(UInt8)
+      endian = endian_byte == 0x01 ? IO::ByteFormat::LittleEndian : IO::ByteFormat::BigEndian
+      type = io.read_bytes UInt32, endian
+      unless type == 0x20000003
+        raise DecodingError.new("This geography is not Polygon2D: #{type.to_s(16)}")
+      end
+      srid = endian.decode(UInt32, io)
+      @sections = Array(Array(Point2D)).new(endian.decode(UInt32, io)) do
+        Array(Point2D).new(endian.decode(UInt32, io)) do
+          Point2D.new(
+            x: endian.decode(Float64, io),
+            y: endian.decode(Float64, io),
+            srid: srid,
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
\* I am a Japanese who is not good at English.
\* Please forgive me for using machine-translated English from Japanese at DeepL.

Currently in this library, I get an error with `select` in `geography`.
For example, if I run `db.query_one "SELECT 'point(1 2 3)'::geography", as: PostGIS::Point3D` in README.
`
Exception: In PG::ResultSet#read the column geography returned a Slice(UInt8) but a PostGIS::Point3D was expected. (DB::ColumnTypeMismatchError )`

This pull request solves that problem.